### PR TITLE
feat(application-layer-bundle): generate command map from method names

### DIFF
--- a/src/Snicco/bundle/application-layer-bundle/src/ApplicationLayerBundle.php
+++ b/src/Snicco/bundle/application-layer-bundle/src/ApplicationLayerBundle.php
@@ -6,7 +6,7 @@ namespace Snicco\Enterprise\Bundle\ApplicationLayer;
 
 use League\Tactician\Handler\CommandHandlerMiddleware;
 use League\Tactician\Handler\CommandNameExtractor\ClassNameExtractor;
-use League\Tactician\Logger\Formatter\ClassNameFormatter;
+use League\Tactician\Logger\Formatter\ClassPropertiesFormatter;
 use League\Tactician\Logger\LoggerMiddleware;
 use League\Tactician\Middleware;
 use Psr\Log\LoggerInterface;
@@ -21,6 +21,7 @@ use Snicco\Component\Kernel\Kernel;
 use Snicco\Component\Kernel\ValueObject\Environment;
 use Snicco\Enterprise\Bundle\ApplicationLayer\Command\CommandBus;
 use Snicco\Enterprise\Bundle\ApplicationLayer\Command\CommandBusOption;
+use Snicco\Enterprise\Bundle\ApplicationLayer\Command\CommandLogger;
 use Snicco\Enterprise\Bundle\ApplicationLayer\Command\GenerateCommandMap;
 use Snicco\Enterprise\Bundle\ApplicationLayer\Command\MapCommandToApplicationService;
 use Snicco\Enterprise\Bundle\ApplicationLayer\Command\Middleware\BetterWPDBTransaction;
@@ -94,7 +95,7 @@ final class ApplicationLayerBundle implements Bundle
             $container,
             $config
         ): CommandHandlerMiddleware {
-            /** @var array<class-string,class-string> $map */
+            /** @var array<class-string, array{0:class-string, 1:string}> $map */
             $map = $config->getArray('command_bus.command-map');
 
             $name_extractor = new ClassNameExtractor();
@@ -108,8 +109,8 @@ final class ApplicationLayerBundle implements Bundle
     private function bindLoggerMiddleware(DIContainer $container): void
     {
         $container->shared(LoggerMiddleware::class, fn (): LoggerMiddleware => new LoggerMiddleware(
-            new ClassNameFormatter(),
-            $container[LoggerInterface::class] ?? new NullLogger()
+            new ClassPropertiesFormatter(),
+            $container[CommandLogger::class] ?? $container[LoggerInterface::class] ?? new NullLogger()
         ));
     }
 

--- a/src/Snicco/bundle/application-layer-bundle/src/Command/CommandLogger.php
+++ b/src/Snicco/bundle/application-layer-bundle/src/Command/CommandLogger.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Snicco\Enterprise\Bundle\ApplicationLayer\Command;
+
+use Psr\Log\LoggerInterface;
+
+/**
+ * Marker interface to allow using a more customized logger for commands.
+ */
+interface CommandLogger extends LoggerInterface
+{
+}

--- a/src/Snicco/bundle/application-layer-bundle/src/Command/GenerateCommandMap.php
+++ b/src/Snicco/bundle/application-layer-bundle/src/Command/GenerateCommandMap.php
@@ -37,7 +37,7 @@ final class GenerateCommandMap
     /**
      * @throws ReflectionException
      *
-     * @return array<class-string,class-string>
+     * @return array<class-string,array{0:class-string, 1: string}>
      */
     public function __invoke(): array
     {
@@ -45,7 +45,9 @@ final class GenerateCommandMap
 
         foreach ($this->application_services as $application_service) {
             $reflection_class = new ReflectionClass($application_service);
+            /** @var ReflectionMethod[] $public_methods */
             $public_methods = $reflection_class->getMethods(ReflectionMethod::IS_PUBLIC);
+
             $public_methods = array_filter(
                 $public_methods,
                 fn (ReflectionMethod $method): bool => 1 === $method->getNumberOfParameters() && ! $method->isConstructor()
@@ -72,7 +74,7 @@ final class GenerateCommandMap
                     $name,
                     sprintf('Command %s can not be handled by two application services.', $name)
                 );
-                $map[$name] = $application_service;
+                $map[$name] = [$application_service, $public_method->getName()];
             }
         }
 

--- a/src/Snicco/bundle/application-layer-bundle/tests/fixtures/Command/TestApplicationService.php
+++ b/src/Snicco/bundle/application-layer-bundle/tests/fixtures/Command/TestApplicationService.php
@@ -15,7 +15,7 @@ final class TestApplicationService
         $this->class = $class;
     }
 
-    public function rentMovie(RentMovieCommand $command): void
+    public function __invoke(RentMovieCommand $command): void
     {
         $command->handled = true;
     }


### PR DESCRIPTION
Instead of generating the command map based on the
command class name we now use the method name.